### PR TITLE
refactored, added ability to find backticks and triple quotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,13 @@
-##Unquote for SublimeText 3
+## Unquote for Sublime Text
 
-A super simple package for quickly removing quotes from a string.  Highlight quoted text and hit default keybinding of `command-'`.
+A super simple package for quickly removing quotes and backticks from around a selected string. It also works with triple-quoted Python docstrings and triple-backtick Markdown code fences. The quotes can either be inside the selection or immediately surrounding it.
 
-###License
+### Use
+
+Highlight quoted text and hit default keybinding of `command-'` (`win-'` on Windows).
+
+The [***Expand Selection to Quotes***](https://packagecontrol.io/packages/Expand%20Selection%20to%20Quotes) package complements this one very well.
+
+## License
+
 Licensed under [MIT](http://opensource.org/licenses/MIT)

--- a/unquote.py
+++ b/unquote.py
@@ -1,23 +1,48 @@
-import sublime, sublime_plugin
+import sublime_plugin
 from sublime import Region
 
+from operator import neg, mul
+
 class UnquoteCommand(sublime_plugin.TextCommand):
-  def run(self, edit):
-    v = self.view
 
-    for region in v.sel():
-      text = v.substr(region)
-      # if the selection starts and ends with matching quotes, just remove them
-      # otherwise expand the selection on char each way and try that
-      if((text.startswith("'") and text.endswith("'")) or (text.endswith('"') and text.endswith('"')) or (text.endswith('`') and text.endswith('`'))):
-        v.erase(edit, Region(region.end() - 1, region.end()))
-        v.erase(edit, Region(region.begin(), region.begin() + 1))
-      else:
-        leftQuoteRegion = Region(region.begin() - 1, region.begin())
-        rightQuoteRegion = Region(region.end(), region.end() + 1)
-        leftChar = v.substr(leftQuoteRegion)
-        rightChar = v.substr(rightQuoteRegion)
+    def run(self, edit):
+        """ If the selection starts and ends with matching quotes, just remove them.
+            Otherwise, expand the selection one char each way and try again.
+        """
+        v = self.view
 
-        if((leftChar == "'" and rightChar == "'") or (leftChar == '"' and rightChar == '"') or (leftChar == '`' and rightChar == '`')):
-          v.erase(edit, rightQuoteRegion);
-          v.erase(edit, leftQuoteRegion);
+        def find_num_quotes(reg, size=1):
+            """ Find `size` number of quotes/backticks in Region `reg`.
+                Returns number of chars to delete on either end.
+            """
+            text = v.substr(reg)
+            chars = 0 # default to not finding (and erasing) anything
+
+            for x in ["'", '"', "`"]:
+                if (text[0:size] == text[neg(size):] == mul(x, size)): # slicing FTW!
+                    chars = size
+
+            return chars
+
+        def trimquotes(reg, chars=0):
+            """ Erase `char` characters from either end of Region `reg`
+            """
+            v.erase(edit, Region(reg.end() - chars, reg.end()))
+            v.erase(edit, Region(reg.begin(), reg.begin() + chars))
+
+        def grow_region(reg, size=0):
+            """ Expand Region `reg` by `size` chars on each end
+            """
+            return Region(reg.begin() - size, reg.end() + size)
+
+        for reg in v.sel():
+            trimsize = find_num_quotes(reg, 3) or find_num_quotes(reg, 1)
+            if trimsize: # the selection includes quotes
+                trimquotes(reg, trimsize)
+            else: # we can't find quotes yet...
+                newreg = grow_region(reg, 3)
+                if find_num_quotes(newreg, 3): # we found a triplet
+                    trimquotes(newreg, 3)
+                else:
+                    newreg = grow_region(reg, 1)
+                    trimquotes(newreg, find_num_quotes(newreg))


### PR DESCRIPTION
I basically rewrote the plugin so it now removes single and triple single quotes `'`, double quotes `"`, and backticks <code>`</code>. Triple quotes are used in Python docstrings, and triple backticks are used in Markdown code fences. The quotes (single or triple) can either be within the original selection or just outside it.

Let me know if you have any questions.